### PR TITLE
Pass data into simulator using data streams

### DIFF
--- a/documentation/data_stream_to_state.md
+++ b/documentation/data_stream_to_state.md
@@ -1,0 +1,22 @@
+# Data Stream To State
+## Discrete simulation from data streams
+Say a discrete simulator has the following three states:
+State 0:
+- Location sensor: (0, 0)
+- Visual sensor: (Up, Right)
+- Wheel controller: Right
+State 1:
+- Location sensor: (1, 0)
+- Visual sensor: (Up, Right, Left)
+- Wheel controller: Up
+State 2:
+- Location sensor: (1, 1)
+- Visual sensor: (Up, Right, Left, Down)
+- Wheel controller: Left
+
+Converted to pure data streams, this would be:
+- Location sensor: (0, 0), (1, 0), (1, 1)
+- Visual sensor: (Up, Right), (Up, Right, Left), (Up, Right, Left, Down)
+- Wheel controller: Right, Up, Left
+
+To map data streams to discrete states, the simulator needs to know what each datastream represents. For example, with the above, the location sensor can be used to ID the state, the visual sensor defines the possible transitions, and the wheel controller is used to define the concrete transitions. 

--- a/maze_generator/test/test_maze_generation.py
+++ b/maze_generator/test/test_maze_generation.py
@@ -10,7 +10,6 @@ class TestMazeGeneration(unittest.TestCase):
             num_rows = 11
             num_cols = 11
             generated_maze = Maze(num_rows, num_cols)
-            print(generated_maze)
             free_spots = []
             for col in range(num_cols):
                 for row in range(num_rows):

--- a/maze_generator/test/test_maze_solver.py
+++ b/maze_generator/test/test_maze_solver.py
@@ -28,7 +28,6 @@ class TestMazeSolver(unittest.TestCase):
             num_rows = 11
             num_cols = 11
             generated_maze = Maze(num_rows, num_cols)
-            print(generated_maze)
             maze_solver = MazeSolver(generated_maze)
             maze_solver.reset()
             self.assertFalse(maze_solver.is_complete())

--- a/src/samples/maze/location_sensor.py
+++ b/src/samples/maze/location_sensor.py
@@ -1,25 +1,19 @@
-from src.observer_pattern.observable import Observable
+from src.simulator.data_stream_types import DataStreamTypes
 
-class LocationSensor(Observable):
-    def __init__(self, maze):
-        Observable.__init__(self)
+class LocationSensor(object):
+    def __init__(self, simulator, maze):
+        self.simulator = simulator
         self.controller = maze
-        
-        self.readings = []
+
+        self.simulator.open_data_stream(self.get_id(), DataStreamTypes.STATE_ID)
 
     def get_id(self):
         return id(self)
 
     def read(self):
         reading = self.controller.get_current_coordinate()
-        self.readings.append(reading)
-        self.notify()
+        self.simulator.notify_new_sensor_value(self.get_id(), reading)
         return reading
-    
-    def get_latest_reading(self):
-        if len(self.readings) > 0:
-            return self.readings[-1]
-        return None
     
     def set_controller(self, new_controller):
         self.controller = new_controller

--- a/src/samples/maze/maze_simulator_controller.py
+++ b/src/samples/maze/maze_simulator_controller.py
@@ -8,7 +8,13 @@ class MazeSimulatorController(SimulatorController):
         return self.current_state.get_state_key_info()
     
     def get_possible_actions(self):
-        return self.current_state.get_possible_transition_names()
+        unfiltered_names = self.current_state.get_possible_transition_names()
+        filtered_names = []
+        for transition_name in unfiltered_names:
+            if self.simulator.get_state_after_action(self.current_state, transition_name) is not None:
+                filtered_names.append(transition_name)
+        return filtered_names
     
     def execute_action(self, action_name):
-        return self.simulator.get_state_after_action(self.current_state, action_name)
+        self.current_state = self.simulator.get_state_after_action(self.current_state, action_name)
+        return self.current_state

--- a/src/samples/maze/visual_sensor.py
+++ b/src/samples/maze/visual_sensor.py
@@ -1,24 +1,19 @@
-from src.observer_pattern.observable import Observable
+from src.simulator.data_stream_types import DataStreamTypes
 
-class VisualSensor(Observable):
-    def __init__(self, maze):
-        Observable.__init__(self)
+class VisualSensor(object):
+    def __init__(self, simulator, maze):
+        self.simulator = simulator
         self.controller = maze
-        self.readings = []
+
+        self.simulator.open_data_stream(self.get_id(), DataStreamTypes.POSSIBLE_TRANSITIONS)
 
     def get_id(self):
         return id(self)
 
     def read(self):
         reading = self.controller.get_possible_actions()
-        self.readings.append(reading)
-        self.notify()
+        self.simulator.notify_new_sensor_value(self.get_id(), reading)
         return reading
-    
-    def get_latest_reading(self):
-        if len(self.readings) > 0:
-            return self.readings[-1]
-        return None
     
     def set_controller(self, new_controller):
         self.controller = new_controller

--- a/src/samples/maze/wheel_controller.py
+++ b/src/samples/maze/wheel_controller.py
@@ -1,22 +1,24 @@
-from src.observer_pattern.observable import Observable
+from src.simulator.data_stream_types import DataStreamTypes
 
-class WheelController(Observable):
-    def __init__(self, controller):
-        Observable.__init__(self)
-        self.previous_actions = []
+class WheelController(object):
+    def __init__(self, simulator, controller):
+        self.simulator = simulator
         self.controller = controller
 
+        self.previous_action = None
+
+        self.simulator.open_data_stream(self.get_id(), DataStreamTypes.CONCRETE_TRANSITIONS)
+
     def execute_action(self, action):
-        self.previous_actions.append(action)
+        self.previous_action = action
         self.controller.execute_action(action)
+        self.simulator.notify_new_sensor_value(self.get_id(), action)
 
     def get_id(self):
         return id(self)        
     
-    def get_latest_action(self):
-        if len(self.previous_actions) > 0:
-            return self.previous_actions[-1]
-        return None
+    def get_previous_action(self):
+        return self.previous_action
     
     def set_controller(self, new_controller):
         self.controller = new_controller

--- a/src/simulator/data_stream_types.py
+++ b/src/simulator/data_stream_types.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class DataStreamTypes(Enum):
+    STATE_ID = 1
+    POSSIBLE_TRANSITIONS = 2
+    CONCRETE_TRANSITIONS = 3

--- a/src/simulator/simulator.py
+++ b/src/simulator/simulator.py
@@ -93,7 +93,7 @@ class Simulator(object):
         
         self._reset_models()
 
-    def export_configuration(self):
+    def get_config(self):
         return self.config
 
     def get_start_state(self):

--- a/src/simulator/simulator_controller.py
+++ b/src/simulator/simulator_controller.py
@@ -10,7 +10,11 @@ class SimulatorController(object):
         self.current_state = self.simulator.get_start_state()
 
     def is_complete(self):
+        print(self.current_state, self.simulator.get_end_state())
         return self.current_state == self.simulator.get_end_state()
     
     def get_current_state(self):
         return self.current_state
+    
+    def set_state(self, new_state):
+        self.current_state = new_state

--- a/src/simulator/simulator_controller.py
+++ b/src/simulator/simulator_controller.py
@@ -10,7 +10,6 @@ class SimulatorController(object):
         self.current_state = self.simulator.get_start_state()
 
     def is_complete(self):
-        print(self.current_state, self.simulator.get_end_state())
         return self.current_state == self.simulator.get_end_state()
     
     def get_current_state(self):

--- a/src/simulator/simulator_data_stream.py
+++ b/src/simulator/simulator_data_stream.py
@@ -1,0 +1,4 @@
+class SimulatorDataStream(object):
+    def __init__(self, simulator):
+        self.simulator = simulator
+        self.simulator.register_data_stream(self)

--- a/src/simulator/simulator_state.py
+++ b/src/simulator/simulator_state.py
@@ -43,4 +43,10 @@ class SimulatorState(object):
         return True
     
     def __str__(self):
-        return str(self.state_key_info)
+        info = {
+            "STATE_KEY_INFO": self.state_key_info,
+            "IS_START_STATE": self.is_start_state,
+            "IS_END_STATE": self.is_end_state,
+            "POSSIBLE_TRANSITION_NAMES": self.get_possible_transition_names()
+        }
+        return str(info)

--- a/test/test_simulator_configuration.py
+++ b/test/test_simulator_configuration.py
@@ -12,7 +12,7 @@ class TestSimulatorConfiguration(unittest.TestCase):
         expected_config = json.load(
             open(os.path.join(os.path.dirname(__file__), "../src/simulator/default_simulator_config.json"))
         )
-        actual_config = test_sim.export_configuration()
+        actual_config = test_sim.get_config()
         self.assertEqual(expected_config, actual_config)
 
     def test_extra_simulator_configuration_can_be_specified_using_a_dictionary(self):
@@ -21,7 +21,7 @@ class TestSimulatorConfiguration(unittest.TestCase):
         )
         expected_config["ready_for_use_threshold_percentage"] = expected_config["ready_for_use_threshold_percentage"] - 1
         test_sim = Simulator(additional_config_dict=expected_config)
-        actual_config = test_sim.export_configuration()
+        actual_config = test_sim.get_config()
         self.assertEqual(expected_config, actual_config)
 
     def test_extra_simulator_configuration_can_be_specified_using_a_file(self):
@@ -33,7 +33,7 @@ class TestSimulatorConfiguration(unittest.TestCase):
         with open(file_path, 'w') as json_file:
             json.dump(expected_config, json_file)
         test_sim = Simulator(additional_config_path=file_path)
-        actual_config = test_sim.export_configuration()
+        actual_config = test_sim.get_config()
         self.assertEqual(expected_config, actual_config)
         os.remove(file_path)
 


### PR DESCRIPTION
https://github.com/users/BramSrna/projects/17?pane=issue&itemId=37651766
https://github.com/users/BramSrna/projects/17/views/1?pane=issue&itemId=37651772
https://github.com/users/BramSrna/projects/17/views/1?pane=issue&itemId=37651778

Updates the simulator so that instead of passing in seperate state and transition information, the simulator now accepts data streams that can receive continuous values. The simulator then maps these values onto discrete states in the state machine. Data streams to the simulator can be paused using the set_accept_new_data method.

There are three types of data streams:
- STATE_ID: Used to generate unique IDs for states (Ex. the location in the maze)
- POSSIBLE_TRANSITIONS: Used to get possible transitions for the states (Ex. the possible directions at each location in the maze)
- CONCRETE_TRANSITIONS: Used to get concrete transitions for states (Ex. the actual directions travelled in the maze)